### PR TITLE
Make creationDate field of project nullable

### DIFF
--- a/entities/project.ts
+++ b/entities/project.ts
@@ -36,7 +36,7 @@ export class Project {
   @Column({ nullable: true })
   organisationId?: number
 
-  @Field()
+  @Field({ nullable: true })
   @Column({ nullable: true })
   creationDate: Date
 


### PR DESCRIPTION
Current values of creationDate field of project entities in db are all null! Graphql queries which includes this field throw error